### PR TITLE
Improve instructions for downloading configuration patch file

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,12 @@ git clone git@github.com:path/to/my-repo.git
 
 ## Download and apply the patch file
 
-Download [fair4rs\_config.patch](https://raw.githubusercontent.com/RSE-Sheffield/fair4rs-lesson-setup/main/fair4rs_config.patch).
+Download
+[fair4rs\_config.patch](https://raw.githubusercontent.com/RSE-Sheffield/fair4rs-lesson-setup/main/fair4rs_config.patch)
+by right-clicking and choosing "Save page as...".  Note that on
+Windows the file may be saved with the `.txt` file extension, which
+means that you'll need to modify the file name in the `git apply`
+command below.
 
 Apply the patch file to the lesson repository:
 


### PR DESCRIPTION
As noted by @RicCampbell in #20, if the patch file is saved in Notepad on Windows then the line endings get messed up which stops the patch applying cleanly.

This PR updates the README to guide user to download the patch file without modification, to avoid problems with incorrect line endings making the patch fail to apply, and notes that on Windows the file may be saved with a '.txt' extension which needs to be carried forward to the `git apply`.